### PR TITLE
Go up the category tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Feature
+- Goes up the category tree and send an event for each parent category
 
 ## [0.2.0] - 2020-04-03
 ### Feature

--- a/node/middlewares/notify.ts
+++ b/node/middlewares/notify.ts
@@ -141,14 +141,14 @@ export async function notify(ctx: Context, next: () => Promise<any>) {
 
   metrics.batch('changed-entities', undefined, changedEntities)
 
-  if (LINKED) {
+  if (!isEmpty(logWholeProductAndSku.sku) && !isEmpty(logWholeProductAndSku.product)) {
     logger.debug({
       'sku': logWholeProductAndSku.sku,
       'product': logWholeProductAndSku.product
     })
   }
 
-  if (!production) {
+  if (LINKED) {
     console.log('changedEntities', changedEntities, { sku: sku.id, brand: brand.id, product: product.id, categories: changedCategoriesIds})
   }
 

--- a/node/middlewares/notify.ts
+++ b/node/middlewares/notify.ts
@@ -1,6 +1,5 @@
-import { Clients } from './../clients/index';
-import { IOContext, IOClients, CatalogGraphQL } from '@vtex/api'
-import { isEmpty, isNil, pluck } from 'ramda'
+import { IOContext, IOClients } from '@vtex/api'
+import { isEmpty, isNil } from 'ramda'
 
 import { USER_BUCKET } from '../constants'
 import {
@@ -18,7 +17,6 @@ import {
   productChanged,
   skuChanged,
 } from './../utils/event'
-import { Category } from '@vtex/api/lib/clients/apps/catalogGraphQL/category'
 
 const isStorage = (maybeStorage: {} | Storage | null): maybeStorage is Storage => {
   if (isNil(maybeStorage) || isEmpty(maybeStorage)) {
@@ -48,7 +46,7 @@ const replaceIfChanged = async <T>(
 }
 
 const getAllCategories = async (categoryId: string | undefined, ctx: Context): Promise<IdentifiedCategory[]> => {
-  const { clients: { catalogGraphQL }, vtex: logger } = ctx
+  const { clients: { catalogGraphQL }, vtex: { logger }} = ctx
   if (!categoryId) {
     return []
   }
@@ -61,7 +59,7 @@ const getAllCategories = async (categoryId: string | undefined, ctx: Context): P
   const parentCategory = categories[0]
   const identifiedCategory = {
     ...category,
-    parentsNames: [...parentCategory.parentsNames, parentCategory.name]
+    parentsNames:  parentCategory ? [...parentCategory.parentsNames, parentCategory.name] : []
   }
   return [identifiedCategory, ...categories]
 }

--- a/node/middlewares/notify.ts
+++ b/node/middlewares/notify.ts
@@ -69,7 +69,7 @@ export async function notify(ctx: Context, next: () => Promise<any>) {
     clients: { catalogGraphQL, events },
     clients,
     body: { IdSku, indexBucket },
-    vtex: { production, logger },
+    vtex: { logger },
   } = ctx
   const bucket = indexBucket || USER_BUCKET
   const eventPromises = []

--- a/node/package.json
+++ b/node/package.json
@@ -5,7 +5,7 @@
   "devDependencies": {
     "@types/node": "12.x",
     "@types/ramda": "types/npm-ramda#dist",
-    "@vtex/api": "6.24.3",
+    "@vtex/api": "6.24.4",
     "eslint": "^6.3.0",
     "eslint-config-vtex": "^11.0.0",
     "prettier": "^1.18.2",

--- a/node/typings.ts
+++ b/node/typings.ts
@@ -1,3 +1,4 @@
+import { Category } from '@vtex/api/lib/clients/apps/catalogGraphQL/category'
 import { RecorderState, EventContext, ServiceContext as ServiceCtx, ParamsContext } from '@vtex/api'
 import { Clients } from './clients/index'
 
@@ -13,6 +14,10 @@ declare global {
     HasStockKeepingUnitModified: boolean
     IdSku: string
     indexBucket?: string
+  }
+
+  interface IdentifiedCategory extends Category {
+    parentsNames: string[]
   }
 
   type ID = string

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -184,10 +184,10 @@
     lodash.unescape "4.0.1"
     semver "5.5.0"
 
-"@vtex/api@6.24.3":
-  version "6.24.3"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.24.3.tgz#8b60e8ddf9440528cbec6233d99a818b5afb6bb8"
-  integrity sha512-0DID7jBZfP6awgVieoKW29NcBbqwW4WBupD3WRMUzBjSLN87ucX4srY2XiQD68/ACUtP/9dByt8ijJNTEv03ZA==
+"@vtex/api@6.24.4":
+  version "6.24.4"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.24.4.tgz#e39c5c87c01fe287ce0aaac9acc7c7acd224f7a1"
+  integrity sha512-w/wSmNQjvG0CQBGic/KPGD4l+yGIam2LMORlubt68bb6qA5j/21Fijfy8N9HFEwo+rmQAYnutMJGVzSQUlBh9A==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"


### PR DESCRIPTION
Currently broadcaster worker is sending the event of the products category, and store-indexer goes up the category tree indexing all parent categories. This causes a lot of redundant operations.

This PR aims to avoid this by making `broadcaster-worker` go up the category tree and sending an event for each parent category (if it has changed). 