### PR TITLE
Increases sleep time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Increased sleep time due to 5 requests per minute limit
 
 ## [0.3.1] - 2020-04-13
 ### Changed

--- a/node/middlewares/indexRoutes.ts
+++ b/node/middlewares/indexRoutes.ts
@@ -37,7 +37,7 @@ const index = async (ctx: ServiceContext) => {
     }
     from += PAGE_LIMIT
     to += PAGE_LIMIT
-    await sleep(1000)
+    await sleep(6000)
   } while(skuIds.length)
   logger.info(`Indexation of ${totalProcessedProducts} products complete`)
 }

--- a/node/package.json
+++ b/node/package.json
@@ -9,7 +9,10 @@
     "eslint": "^6.3.0",
     "eslint-config-vtex": "^11.0.0",
     "prettier": "^1.18.2",
-    "typescript": "3.8.3"
+    "typescript": "3.8.3",
+    "vtex.broadcaster-worker": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.broadcaster-worker@0.3.1/public/_types/react",
+    "vtex.catalog-api-proxy": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.catalog-api-proxy@0.7.2/public/_types/react",
+    "vtex.catalog-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.catalog-graphql@1.70.3/public/@types/vtex.catalog-graphql"
   },
   "scripts": {
     "lint": "tsc --noEmit --pretty && eslint -c .eslintrc.json --fix './**/*.ts'"

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -2409,6 +2409,18 @@ vary@^1.1.2:
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=
 
+"vtex.broadcaster-worker@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.broadcaster-worker@0.3.1/public/_types/react":
+  version "0.0.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.broadcaster-worker@0.3.1/public/_types/react#fa7a0347e046eab3dd768998fc9252b2c0dd5aef"
+
+"vtex.catalog-api-proxy@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.catalog-api-proxy@0.7.2/public/_types/react":
+  version "0.0.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.catalog-api-proxy@0.7.2/public/_types/react#fa7a0347e046eab3dd768998fc9252b2c0dd5aef"
+
+"vtex.catalog-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.catalog-graphql@1.70.3/public/@types/vtex.catalog-graphql":
+  version "1.70.3"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.catalog-graphql@1.70.3/public/@types/vtex.catalog-graphql#fedab49a0c2fcc2f2a991021643c70ebed56ab20"
+
 which@^1.2.9:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"


### PR DESCRIPTION
Since the `GetProductsAndSkuIds` API has a limit of 5 requests per minute per account. We need to increase the sleep time between requests, so that, the limit is not reached and all routes are indexed.

Each request gets 20 products, for each product it sends an event and waits 300 milliseconds, so a total of 6 seconds. Therefore we need to wait 6 more seconds before the next request.