### PR TITLE
Refactor to use events

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema",
   "name": "broadcaster-worker",
   "vendor": "vtex",
-  "version": "0.3.5-beta.10",
+  "version": "0.3.5-beta.13",
   "title": "Broadcaster Worker",
   "description": "Reference app for VTEX IO Services",
   "dependencies": {

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema",
   "name": "broadcaster-worker",
   "vendor": "vtex",
-  "version": "0.3.4",
+  "version": "0.3.5-beta.0",
   "title": "Broadcaster Worker",
   "description": "Reference app for VTEX IO Services",
   "dependencies": {

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema",
   "name": "broadcaster-worker",
   "vendor": "vtex",
-  "version": "0.3.5-beta.0",
+  "version": "0.3.5-beta.10",
   "title": "Broadcaster Worker",
   "description": "Reference app for VTEX IO Services",
   "dependencies": {

--- a/node/clients/catalog.ts
+++ b/node/clients/catalog.ts
@@ -20,17 +20,19 @@ export class Catalog extends ExternalClient {
           ...(options?.headers ?? {}),
           'Content-Type': 'application/json',
           'X-Vtex-Use-Https': 'true',
-          ...context.adminUserAuthToken ? { VtexIdclientAutCookie: context.adminUserAuthToken } : {},
         }, 
       }
     )
   }
 
-  public getProductsAndSkuIds (from: number, to: number): Promise<GetProductsAndSkuIdsReponse>{
+  public getProductsAndSkuIds (from: number, to: number, authToken?: string): Promise<GetProductsAndSkuIdsReponse>{
     return this.http.get('/api/catalog_system/pvt/products/GetProductAndSkuIds', {
       params: {
         _from: from,
         _to: to
+      },
+      headers: {
+        ...authToken ? { VtexIdclientAutCookie: authToken } : {},
       }
     })
   }

--- a/node/index.ts
+++ b/node/index.ts
@@ -53,7 +53,7 @@ export default new Service<Clients, State, ParamsContext>({
     broadcasterNotification: [
       throttle, locale, notify,
     ],
-    indexRoutes: indexRoutes,
+    indexRoutes,
   },
   routes: {
     indexRoutes: [validation, indexAllRoutes],

--- a/node/index.ts
+++ b/node/index.ts
@@ -3,7 +3,7 @@ import { LRUCache, Service, Cached, ParamsContext } from '@vtex/api'
 import { locale } from './middlewares/locale'
 import { notify } from './middlewares/notify'
 import { throttle } from './middlewares/throttle'
-import { indexRoutes } from './middlewares/indexRoutes'
+import { indexRoutes, indexAllRoutes } from './middlewares/indexRoutes'
 import { Clients } from './clients'
 import { validation } from './middlewares/validation'
 
@@ -53,8 +53,9 @@ export default new Service<Clients, State, ParamsContext>({
     broadcasterNotification: [
       throttle, locale, notify,
     ],
+    indexRoutes: indexRoutes,
   },
   routes: {
-    indexRoutes: [validation, indexRoutes],
+    indexRoutes: [validation, indexAllRoutes],
   },
 })

--- a/node/index.ts
+++ b/node/index.ts
@@ -6,6 +6,7 @@ import { throttle } from './middlewares/throttle'
 import { indexRoutes, indexAllRoutes } from './middlewares/indexRoutes'
 import { Clients } from './clients'
 import { validation } from './middlewares/validation'
+import { nextEvent } from './middlewares/nextEvent'
 
 const TREE_SECONDS_MS = 3 * 1000
 const CONCURRENCY = 10
@@ -53,7 +54,7 @@ export default new Service<Clients, State, ParamsContext>({
     broadcasterNotification: [
       throttle, locale, notify,
     ],
-    indexRoutes,
+    indexRoutes: [indexRoutes, nextEvent],
   },
   routes: {
     indexRoutes: [validation, indexAllRoutes],

--- a/node/middlewares/indexRoutes.ts
+++ b/node/middlewares/indexRoutes.ts
@@ -56,7 +56,13 @@ const index = async (ctx: Context) => {
     productsWithoutSKU: productsWithoutSKU + PAGE_LIMIT - skuIds.length,
   }
   if (payload.processedProducts >= total || payload.from >= total) {
-    logger.info({ message: `Indexation complete`, processedProducts, productsWithoutSKU, total, indexBucket })
+    logger.info({ 
+      message: `Indexation complete`, 
+      processedProducts: payload.processedProducts, 
+      productsWithoutSKU: payload.productsWithoutSKU, 
+      total, 
+      indexBucket 
+    })
     await vbase.deleteFile(BUCKET, FILE)
     return
   } else {

--- a/node/middlewares/indexRoutes.ts
+++ b/node/middlewares/indexRoutes.ts
@@ -1,59 +1,79 @@
 import { sleep } from '../utils/event'
 
 const BROADCASTER_NOTIFICATION = 'broadcaster.notification'
+const BROACASTER_INDEX_ROUTES = 'broadcaster.indexRoutes'
 const PAGE_LIMIT = 20
 
-const index = async (ctx: ServiceContext) => {
-  const { clients: { catalog, events }, vtex: { logger } } = ctx
-  let skuIds: number[] = []
-  let from = 0
-  let to = PAGE_LIMIT - 1
-  let processedProducts = 0
-  let productsWithoutSKU = 0
-  let totalProducts
+export async function indexRoutes(ctx: Context) {
+  const { clients: { catalog, events }, vtex: { logger }, body } = ctx
+  const { 
+    indexBucket,
+    from,
+    processedProducts,
+    productsWithoutSKU,
+    authToken,
+  }: IndexRoutesEvent = body
+  const to = from + PAGE_LIMIT - 1
+  const { data, range: { total } } = await catalog.getProductsAndSkuIds(from, to, authToken)
+  if (processedProducts >= total || from >= total) {
+    logger.info({ message: `Indexation complete`, processedProducts, productsWithoutSKU, total, indexBucket })
+    return
+  }
 
-  const indexBucket = (Math.random() * 10000).toString()
-  do {
-    const { data, range: { total } } = await catalog.getProductsAndSkuIds(from, to)
-    if (!totalProducts) {
-      totalProducts = total
-    }
-    const productIds = Object.keys(data)
-    skuIds = productIds.reduce((acc, productId) => {
-      const skus = data[productId]
-      if (skus.length) {
-        const skuId = skus[0]
-        acc.push(skuId)
-        processedProducts += 1
-      } else {
-        productsWithoutSKU += 1
-      }
-      return acc
-    }, [] as number[])
-    for (let idx in skuIds) {
-      const skuId = skuIds[idx]
-      await sleep(300)
-      events.sendEvent('', BROADCASTER_NOTIFICATION, {
-        HasStockKeepingUnitModified: true,
-        IdSku: skuId,
-        indexBucket,
-      }).catch(logger.error)
-    }
-    logger.info({ message: 'Processed', processedProducts, productsWithoutSKU, totalProducts, from })
-    from += PAGE_LIMIT
-    to += PAGE_LIMIT
-    await sleep(6200)
-  } while(processedProducts < totalProducts && from < totalProducts)
-  logger.info({ message: `Indexation complete`, processedProducts, productsWithoutSKU })
+  const productIds = Object.keys(data)
+  const skuIds = productIds.reduce((acc, productId) => {
+    const skus = data[productId]
+    if (skus.length) {
+      const skuId = skus[0]
+      acc.push(skuId)
+    } 
+    return acc
+  }, [] as number[])
+  for (let idx in skuIds) {
+    const skuId = skuIds[idx]
+    await sleep(300)
+    events.sendEvent('', BROADCASTER_NOTIFICATION, {
+      HasStockKeepingUnitModified: true,
+      IdSku: skuId,
+      indexBucket,
+    })
+  }
+  await sleep(6200)
+  const payload: IndexRoutesEvent = {
+    indexBucket,
+    from: from + PAGE_LIMIT, 
+    processedProducts: processedProducts + skuIds.length,
+    productsWithoutSKU: productsWithoutSKU + PAGE_LIMIT - skuIds.length,
+    authToken,
+  } 
+  logger.info({ 
+    message: 'Processed', 
+    processedProducts: payload.processedProducts, 
+    productsWithoutSKU: payload.productsWithoutSKU, 
+    totalProducts: total, 
+    from, 
+    indexBucket,
+  })
+  events.sendEvent('', BROACASTER_INDEX_ROUTES, payload)
 }
 
-export function indexRoutes(ctx: ServiceContext) {
-  const { adminUserAuthToken, logger } = ctx.vtex
+export function indexAllRoutes(ctx: ServiceContext) {
+  const { clients: { events }, vtex: { adminUserAuthToken, logger } } = ctx
   if (!adminUserAuthToken) {
     ctx.status = 401
     logger.error(`Missing adminUserAuth token`)
     return
   }
-  index(ctx)
+  // ADD indexBucket and token in VBASE?
+
+  const indexBucket = (Math.random() * 10000).toString()
+  const payload: IndexRoutesEvent = {
+    indexBucket,
+    from: 0,
+    processedProducts: 0,
+    productsWithoutSKU: 0,
+    authToken: adminUserAuthToken, // ISSO é SEGUTRO?
+  }
+  events.sendEvent('', BROACASTER_INDEX_ROUTES, payload)
   ctx.status = 200
 }

--- a/node/middlewares/nextEvent.ts
+++ b/node/middlewares/nextEvent.ts
@@ -1,0 +1,7 @@
+import { BROACASTER_INDEX_ROUTES } from "./indexRoutes"
+
+export async function nextEvent(ctx: Context) {
+  const { vtex: { logger }, clients: { events }, state: { nextPayload } } = ctx
+  events.sendEvent('', BROACASTER_INDEX_ROUTES, nextPayload)
+  logger.info({ message: 'Event sent', nextPayload })
+}

--- a/node/middlewares/notify.ts
+++ b/node/middlewares/notify.ts
@@ -140,12 +140,12 @@ export async function notify(ctx: Context, next: () => Promise<any>) {
 
   metrics.batch('changed-entities', undefined, changedEntities)
 
-  if (!isEmpty(logWholeProductAndSku.sku) && !isEmpty(logWholeProductAndSku.product)) {
-    logger.debug({
-      'sku': logWholeProductAndSku.sku,
-      'product': logWholeProductAndSku.product
-    })
-  }
+  // if (!isEmpty(logWholeProductAndSku.sku) && !isEmpty(logWholeProductAndSku.product)) {
+  //   logger.debug({
+  //     'sku': logWholeProductAndSku.sku,
+  //     'product': logWholeProductAndSku.product
+  //   })
+  // }
 
   if (LINKED) {
     console.log('changedEntities', changedEntities, { sku: sku.id, brand: brand.id, product: product.id, categories: changedCategoriesIds})

--- a/node/middlewares/notify.ts
+++ b/node/middlewares/notify.ts
@@ -140,12 +140,12 @@ export async function notify(ctx: Context, next: () => Promise<any>) {
 
   metrics.batch('changed-entities', undefined, changedEntities)
 
-  // if (!isEmpty(logWholeProductAndSku.sku) && !isEmpty(logWholeProductAndSku.product)) {
-  //   logger.debug({
-  //     'sku': logWholeProductAndSku.sku,
-  //     'product': logWholeProductAndSku.product
-  //   })
-  // }
+  if (!isEmpty(logWholeProductAndSku.sku) && !isEmpty(logWholeProductAndSku.product)) {
+    logger.debug({
+      'sku': logWholeProductAndSku.sku,
+      'product': logWholeProductAndSku.product
+    })
+  }
 
   if (LINKED) {
     console.log('changedEntities', changedEntities, { sku: sku.id, brand: brand.id, product: product.id, categories: changedCategoriesIds})

--- a/node/package.json
+++ b/node/package.json
@@ -5,7 +5,7 @@
   "devDependencies": {
     "@types/node": "12.x",
     "@types/ramda": "types/npm-ramda#dist",
-    "@vtex/api": "6.26.0",
+    "@vtex/api": "6.27.0",
     "eslint": "^6.3.0",
     "eslint-config-vtex": "^11.0.0",
     "prettier": "^1.18.2",

--- a/node/service.json
+++ b/node/service.json
@@ -8,6 +8,9 @@
   "events": {
     "broadcasterNotification": {
       "keys": ["broadcaster.notification"]
+    },
+    "indexRoutes": {
+      "keys": ["broadcaster.indexRoutes"]
     }
   },
   "routes": {

--- a/node/typings.ts
+++ b/node/typings.ts
@@ -7,6 +7,7 @@ declare global {
   type ServiceContext = ServiceCtx<Clients, State, ParamsContext>
 
   interface State extends RecorderState, BroadcasterEvent, IndexRoutesEvent {
+    nextPayload: IndexRoutesEvent
   }
 
   interface BroadcasterEvent {

--- a/node/typings.ts
+++ b/node/typings.ts
@@ -6,14 +6,21 @@ declare global {
   type Context = EventContext<Clients, State>
   type ServiceContext = ServiceCtx<Clients, State, ParamsContext>
 
-  interface State extends RecorderState, BroadcasterEvent {
-    payload: BroadcasterEvent
+  interface State extends RecorderState, BroadcasterEvent, IndexRoutesEvent {
   }
 
   interface BroadcasterEvent {
     HasStockKeepingUnitModified: boolean
     IdSku: string
     indexBucket?: string
+  }
+
+  interface IndexRoutesEvent {
+    indexBucket?: string
+    from: number
+    processedProducts: number
+    productsWithoutSKU: number
+    authToken: string
   }
 
   interface IdentifiedCategory extends Category {

--- a/node/typings.ts
+++ b/node/typings.ts
@@ -20,6 +20,7 @@ declare global {
     from: number
     processedProducts: number
     productsWithoutSKU: number
+    attempt?: number
   }
 
   interface IdentifiedCategory extends Category {

--- a/node/typings.ts
+++ b/node/typings.ts
@@ -20,7 +20,6 @@ declare global {
     from: number
     processedProducts: number
     productsWithoutSKU: number
-    authToken: string
   }
 
   interface IdentifiedCategory extends Category {

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -184,10 +184,10 @@
     lodash.unescape "4.0.1"
     semver "5.5.0"
 
-"@vtex/api@6.26.0":
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.26.0.tgz#743ed02c812a77b0d9d2c5d5219dcd15e5905d14"
-  integrity sha512-Sdi1jznQugJG7f74kn+aXvrYsrwwT6LUb2QSduzqEuQL3Noc8BaWyzc8JbgUPd0AIH1mjIjjkbsVnXs5uxgwOA==
+"@vtex/api@6.27.0":
+  version "6.27.0"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.27.0.tgz#c19634181915363bc9fa9e1150c5c15aa4b3f25e"
+  integrity sha512-yNkEbjSvKnC2VSAypYK5WaGW/tKmDgvO4kNaI8ZKU5anG3U82QjWWYlqsFZXh0ycvlP9l4+Og2BMHat4YKy+uA==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"


### PR DESCRIPTION
Previously we had a 'for' loop that went through all pages of the `GetProductsAndSkuIds`, this took a lot of time depending on the account. Causing the pod to die and the indexation to stop. 

This PR switches the 'for' loop to an event chain, it sends an event for each page in sequence, avoiding the pod's death.

Some things to note:
1. We save in VBase the index bucket name, and validate it with the receiving index bucket. This allows to invalidate the indexation if another indexation starts, or in case of an emergency
2. We save in VBase the authorization token of the user, since it is not passed in the context of the events
3. We do a fire and forget when receiving an indexing event, because we have a lot of `sleeps` in our code (due to the API throttling) and they were causing `courier` to timeout and retry indefinitely all events. This behavior makes us need to handle retries on our own.

