### PR TITLE
Forwards 429 error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Forwards 429 error
 
 ## [0.4.2] - 2020-11-24
 

--- a/node/index.ts
+++ b/node/index.ts
@@ -7,6 +7,7 @@ import { indexRoutes, indexAllRoutes } from './middlewares/indexRoutes'
 import { Clients } from './clients'
 import { validation } from './middlewares/validation'
 import { nextEvent } from './middlewares/nextEvent'
+import { errors } from './middlewares/errors'
 
 const TREE_SECONDS_MS = 3 * 1000
 const CONCURRENCY = 10
@@ -52,9 +53,9 @@ export default new Service<Clients, State, ParamsContext>({
   },
   events: {
     broadcasterNotification: [
-      throttle, locale, notify,
+      errors, throttle, locale, notify,
     ],
-    indexRoutes: [indexRoutes, nextEvent],
+    indexRoutes: [errors, indexRoutes, nextEvent],
   },
   routes: {
     indexRoutes: [validation, indexAllRoutes],

--- a/node/middlewares/errors.ts
+++ b/node/middlewares/errors.ts
@@ -1,0 +1,23 @@
+import { TooManyRequestsError } from '@vtex/api'
+import { any } from 'ramda'
+
+const ERROR_429 = 'E_HTTP_429'
+
+const isTooManyRequestError = (error: any) => {
+  // Checks if has one error and it is the TooManyRequestError
+  if (error.graphQLErrors && error.graphQLErrors.length === 1) {
+    return any((err: any )=> err.extensions?.exception?.code === ERROR_429 , error.graphQLErrors)
+  }
+  return false
+}
+
+export async function errors(_: Context, next: () => Promise<void>) {
+  try {
+    await next()
+  } catch (error) {
+    if (isTooManyRequestError(error)) {
+      throw new TooManyRequestsError()
+    }
+    throw error
+  }
+}

--- a/node/middlewares/errors.ts
+++ b/node/middlewares/errors.ts
@@ -3,7 +3,7 @@ import { any } from 'ramda'
 
 const ERROR_429 = 'E_HTTP_429'
 
-const isTooManyRequestError = (error: any) => {
+const isTooManyRequestsError = (error: any) => {
   // Checks if has one error and it is the TooManyRequestError
   if (error.graphQLErrors && error.graphQLErrors.length === 1) {
     return any((err: any )=> err.extensions?.exception?.code === ERROR_429 , error.graphQLErrors)
@@ -15,7 +15,7 @@ export async function errors(_: Context, next: () => Promise<void>) {
   try {
     await next()
   } catch (error) {
-    if (isTooManyRequestError(error)) {
+    if (isTooManyRequestsError(error)) {
       throw new TooManyRequestsError()
     }
     throw error

--- a/node/package.json
+++ b/node/package.json
@@ -5,7 +5,7 @@
   "devDependencies": {
     "@types/node": "12.x",
     "@types/ramda": "types/npm-ramda#dist",
-    "@vtex/api": "6.37.0",
+    "@vtex/api": "6.39.1",
     "eslint": "^6.3.0",
     "eslint-config-vtex": "^11.0.0",
     "prettier": "^1.18.2",

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -184,10 +184,10 @@
     lodash.unescape "4.0.1"
     semver "5.5.0"
 
-"@vtex/api@6.37.0":
-  version "6.37.0"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.37.0.tgz#a07e6adbfc02866f901cf0cfff2155f2c279adc5"
-  integrity sha512-Vy970ZfgOttrxeiJW2oM8rQ0E8t/HE5cQhbGIawfJsu35HEWA9NnWRSR3bdLMczT9oYIY9QwE8IfdU4b44dhKw==
+"@vtex/api@6.39.1":
+  version "6.39.1"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.39.1.tgz#ad675cf46404b0d21476ac441626843b6950c4a2"
+  integrity sha512-w3FghXguk4b+bOSOihB8I4+gGt7JljRCXFgirK9XiHDOr+uPsUEGhC4JeeQ42aBIEQeyGmQQOsyvZ+qZp2C/oA==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"


### PR DESCRIPTION
Currently if any dependency starts trowing 429 erros, broadcaster will in turn return an error 500. Causing alarms to be called and maybe the circuit to be open, instead of forwarding a 429 error making the router retry the call in some minutes.