### PR TITLE
Improve indexing concurrency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Improved concurrency handling of `indexRoutes` events.
+- Add settings middleware to the indexRoutes event too.
+- Log debug info when indexing is disabled.
+
+### Fixed
+- Only increment throttle counter when we do process the event.
 
 ## [0.5.0] - 2021-06-01
 

--- a/node/clients/index.ts
+++ b/node/clients/index.ts
@@ -1,8 +1,13 @@
 import { IOClients } from '@vtex/api'
 import { Catalog } from './catalog'
+import { NoCacheVBase } from './noCacheVBase'
 
 export class Clients extends IOClients {
   public get catalog() {
     return this.getOrSet('catalog', Catalog)
+  }
+
+  public get noCacheVBase() {
+    return this.getOrSet('noCacheVBase', NoCacheVBase)
   }
 }

--- a/node/clients/noCacheVBase.ts
+++ b/node/clients/noCacheVBase.ts
@@ -1,0 +1,16 @@
+import { IOContext, InstanceOptions, VBase } from "@vtex/api";
+
+export class NoCacheVBase extends VBase {
+  public constructor(context: IOContext, options?: InstanceOptions) {
+    super(
+      context,
+      {
+        ...(options ?? {}),
+        headers: {
+          ...(options?.headers ?? {}),
+          'Cache-Control': 'no-cache',
+        }, 
+      }
+    )
+  }
+}

--- a/node/index.ts
+++ b/node/index.ts
@@ -56,7 +56,7 @@ export default new Service<Clients, State, ParamsContext>({
     broadcasterNotification: [
       settings, errors, throttle, locale, notify,
     ],
-    indexRoutes: [errors, indexRoutes, nextEvent],
+    indexRoutes: [settings, errors, indexRoutes, nextEvent],
   },
   routes: {
     indexRoutes: [validation, indexAllRoutes],

--- a/node/middlewares/indexRoutes.ts
+++ b/node/middlewares/indexRoutes.ts
@@ -7,7 +7,7 @@ const BUCKET = 'indexRoutes'
 const FILE = 'data.json'
 
 const index = async (ctx: Context, next: () => Promise<void>) => {
-  const { clients: { catalog, events, vbase }, vtex: { logger }, body } = ctx
+  const { clients: { catalog, events, noCacheVBase }, vtex: { logger }, body } = ctx
   logger.info({ message: 'Event received', payload: ctx.body})
   const {
     indexBucket,
@@ -16,7 +16,7 @@ const index = async (ctx: Context, next: () => Promise<void>) => {
     productsWithoutSKU,
   }: IndexRoutesEvent = body
 
-  const { data: dataFile, headers: {etag} } = await vbase.getRawJSON<IndexRoutesEvent>(BUCKET, FILE, true)
+  const { data: dataFile, headers: {etag} } = await noCacheVBase.getRawJSON<IndexRoutesEvent>(BUCKET, FILE, true)
   if (dataFile?.indexBucket != indexBucket) {
     logger.debug({ 
       message: 'Invalid Indexation', 
@@ -77,7 +77,7 @@ const index = async (ctx: Context, next: () => Promise<void>) => {
       total, 
       indexBucket 
     })
-    await vbase.deleteFile(BUCKET, FILE)
+    await noCacheVBase.deleteFile(BUCKET, FILE)
     return
   } else {
     logger.info({
@@ -89,7 +89,7 @@ const index = async (ctx: Context, next: () => Promise<void>) => {
       indexBucket,
     })
 
-    const shouldTriggerNext : boolean = await vbase.saveJSON(BUCKET, FILE, payload, undefined, etag)
+    const shouldTriggerNext : boolean = await noCacheVBase.saveJSON(BUCKET, FILE, payload, undefined, etag)
       .then(_ => true)
       .catch(e => e?.response?.status != 412)
 
@@ -108,10 +108,10 @@ export async function indexRoutes(ctx: Context, next: () => Promise<void>) {
 }
 
 export async function indexAllRoutes(ctx: ServiceContext) {
-  const { clients: { events, vbase } } = ctx
+  const { clients: { events, noCacheVBase } } = ctx
   const indexBucket = (Math.random() * 10000).toString()
   const data = { indexBucket, from: 0 }
-  await vbase.saveJSON(BUCKET, FILE, data)
+  await noCacheVBase.saveJSON(BUCKET, FILE, data)
 
   const payload: IndexRoutesEvent = {
     indexBucket,

--- a/node/middlewares/indexRoutes.ts
+++ b/node/middlewares/indexRoutes.ts
@@ -21,6 +21,7 @@ const index = async (ctx: Context, next: () => Promise<void>) => {
     logger.debug({ 
       message: 'Invalid Indexation', 
       currentIndexBucket: dataFile?.indexBucket, 
+      from,
       receivedIndexBucket: indexBucket
     })
     return

--- a/node/middlewares/settings.ts
+++ b/node/middlewares/settings.ts
@@ -12,6 +12,7 @@ export const DEFAULT_SETTINGS = {
 export async function settings(ctx: Context, next: () => Promise<void>) {
   const {
     clients: { apps },
+    vtex: { logger },
   } = ctx
 
   const { disableIndexation } = {
@@ -19,6 +20,10 @@ export async function settings(ctx: Context, next: () => Promise<void>) {
     ...(await apps.getAppSettings(VTEX_APP_AT_MAJOR) as Settings),
   }
   if (disableIndexation) {
+    logger.debug({
+      message: 'Indexing disabled',
+      ...ctx.body,
+    })
     return
   }
 

--- a/node/middlewares/throttle.ts
+++ b/node/middlewares/throttle.ts
@@ -8,13 +8,14 @@ export async function throttle(
   _: Context,
   next: () => Promise<void>
 ) {
-  COUNTER++
+  if (COUNTER > MAX_REQUEST) {
+    const timeToSleep = Math.ceil(Math.random() * 100)
+    await sleep(timeToSleep)
+    throw new TooManyRequestsError()
+  }
+
   try {
-    if (COUNTER > MAX_REQUEST) {
-      const timeToSleep = Math.ceil(Math.random() * 100)
-      await sleep(timeToSleep)
-      throw new TooManyRequestsError()
-    }
+    COUNTER++
     await next()
   } finally {
     COUNTER--

--- a/node/package.json
+++ b/node/package.json
@@ -5,7 +5,7 @@
   "devDependencies": {
     "@types/node": "12.x",
     "@types/ramda": "types/npm-ramda#dist",
-    "@vtex/api": "6.39.1",
+    "@vtex/api": "6.42.1",
     "eslint": "^6.3.0",
     "eslint-config-vtex": "^11.0.0",
     "prettier": "^1.18.2",

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -184,10 +184,10 @@
     lodash.unescape "4.0.1"
     semver "5.5.0"
 
-"@vtex/api@6.39.1":
-  version "6.39.1"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.39.1.tgz#ad675cf46404b0d21476ac441626843b6950c4a2"
-  integrity sha512-w3FghXguk4b+bOSOihB8I4+gGt7JljRCXFgirK9XiHDOr+uPsUEGhC4JeeQ42aBIEQeyGmQQOsyvZ+qZp2C/oA==
+"@vtex/api@6.42.1":
+  version "6.42.1"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.42.1.tgz#b0030afa16750f995bf8296bdc8b22ce2fa5907b"
+  integrity sha512-b9U+G1ZuZ6MOsbiLn+/FEW/XnTIGnsKam1YxUf7OHJhPY+ebupkxIhFeAWub/Mf8xELaNl+0EdrwUbuq4dNFxQ==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"
@@ -226,6 +226,7 @@
     semver "^5.5.1"
     stats-lite vtex/node-stats-lite#dist
     tar-fs "^2.0.0"
+    tokenbucket "^0.3.2"
     uuid "^3.3.3"
     xss "^1.0.6"
 
@@ -419,6 +420,11 @@ bl@^3.0.0:
   integrity sha512-EUAyP5UHU5hxF8BPT0LKW8gjYLhq1DQIcneOX/pL/m2Alo+OYDQAJlHq+yseMP50Os2nHXOSic6Ss3vSQeyf4A==
   dependencies:
     readable-stream "^3.0.1"
+
+bluebird@2.9.24:
+  version "2.9.24"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-2.9.24.tgz#14a2e75f0548323dc35aa440d92007ca154e967c"
+  integrity sha1-FKLnXwVIMj3DWqRA2SAHyhVOlnw=
 
 bluebird@^3.5.4:
   version "3.5.5"
@@ -1749,6 +1755,11 @@ readable-stream@^3.0.1, readable-stream@^3.1.1:
     string_decoder "^1.1.1"
     util-deprecate "^1.0.1"
 
+redis@^0.12.1:
+  version "0.12.1"
+  resolved "https://registry.yarnpkg.com/redis/-/redis-0.12.1.tgz#64df76ad0fc8acebaebd2a0645e8a48fac49185e"
+  integrity sha1-ZN92rQ/IrOuuvSoGReikj6xJGF4=
+
 regexpp@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-2.0.1.tgz#8d19d31cf632482b589049f8281f93dbcba4d07f"
@@ -2021,6 +2032,14 @@ toidentifier@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553"
   integrity sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==
+
+tokenbucket@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/tokenbucket/-/tokenbucket-0.3.2.tgz#8172b2b58e3083acc8d914426fed15162a3a8e90"
+  integrity sha1-gXKytY4wg6zI2RRCb+0VFio6jpA=
+  dependencies:
+    bluebird "2.9.24"
+    redis "^0.12.1"
 
 ts-invariant@^0.2.1:
   version "0.2.1"


### PR DESCRIPTION
### Goal

Improve indexing concurrency.

### Problems

A race condition between `courier` receiving an error from `broadcaster-worker` and the app sending the event for the next step, caused two `indexRoutes` events for the same indexing pipeline to be created.

Each time this happened, the amount of work to finish the indexing pipeline would increase by the size of the store catalog.

For instance, when `courier` delivered the event:
```json
{
  "from": 336040,
  "indexBucket": 7278.834777878514,
  ...
}
```

`broadcaster-worker` could finish processing it and also send the event:
```json
{
  "from": 336050,
  "indexBucket": 7278.834777878514,
  ...
}
```
But before `broadcaster-worker` sent a `200` responding to the first event, the router could time it out and `courier` would retry the first. Then we would keep processing two indexings, one starting from `336040` and another from `336050`.

This could happen several times, especially under load, multiplying the total effort to reindex the store several times.

### Solution

We implemented a few small improvements:
- Only increment throttle counter when we do process the event.
- Add `settings` middleware to the `indexRoutes` event too.
- Log debug info when indexing is disabled.

And a major one. 

Now we use VBase not only to prevent several indexing pipelines (same `indexBucket` ID) to be triggered at once.
We also prevent the same indexing pipeline to be forked, saving the latest `from` value in the same file. 
And only processing the `indexRoutes` event if it's `from` is equal to or bigger than VBase's.

This won't prevent the same event from being processed twice, but once both are processed only one will trigger the next event, effectively preventing indexing forks.


### TODO
~We should make sure the `vbase.getRawJSON<IndexRoutesEvent>(BUCKET, FILE, true)` gets the latest version of the file.
Adding a `Cache-Control: no-cache` header here would do the trick, but I'm not sure how to do it.~

Done at 99ab3bf.

### Tests
<img width="1680" alt="Screen Shot 2021-06-02 at 10 08 46" src="https://user-images.githubusercontent.com/7853668/120485495-889fa880-c38a-11eb-9e24-ee65b9c8d144.png">

I've tested it over last night on `smartcsb2c`. 
Comparing with the indexing that was triggered on the last 31st, there were no forks.
The 429 rate was bigger than the last indexing, but this happened because Catalog shrank their throttling from 200 calls per minute to 20.  
Since the fork problem is rare, we have no final guarantee that the problem was fixed, so we should keep monitoring it.