### PR TITLE
Add middleware to filter events without HasStockKeepingUnitModified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `filterStock` middleware to filter events without `HasStockKeepingUnitModified` property
 
 ## [0.5.1] - 2021-06-07
 ### Added

--- a/node/index.ts
+++ b/node/index.ts
@@ -9,6 +9,7 @@ import { validation } from './middlewares/validation'
 import { nextEvent } from './middlewares/nextEvent'
 import { errors } from './middlewares/errors'
 import { settings } from './middlewares/settings'
+import { stockFilterEvents } from './middlewares/stockFilter'
 
 const TREE_SECONDS_MS = 3 * 1000
 const CONCURRENCY = 10
@@ -54,7 +55,7 @@ export default new Service<Clients, State, ParamsContext>({
   },
   events: {
     broadcasterNotification: [
-      settings, errors, throttle, locale, notify,
+      stockFilterEvents, settings, errors, throttle, locale, notify,
     ],
     indexRoutes: [settings, errors, indexRoutes, nextEvent],
   },

--- a/node/index.ts
+++ b/node/index.ts
@@ -9,7 +9,7 @@ import { validation } from './middlewares/validation'
 import { nextEvent } from './middlewares/nextEvent'
 import { errors } from './middlewares/errors'
 import { settings } from './middlewares/settings'
-import { stockFilterEvents } from './middlewares/stockFilter'
+import { filterStockEvents } from './middlewares/filterStock'
 
 const TREE_SECONDS_MS = 3 * 1000
 const CONCURRENCY = 10
@@ -55,7 +55,7 @@ export default new Service<Clients, State, ParamsContext>({
   },
   events: {
     broadcasterNotification: [
-      stockFilterEvents, settings, errors, throttle, locale, notify,
+      filterStockEvents, settings, errors, throttle, locale, notify,
     ],
     indexRoutes: [settings, errors, indexRoutes, nextEvent],
   },

--- a/node/middlewares/filterStock.ts
+++ b/node/middlewares/filterStock.ts
@@ -1,0 +1,7 @@
+export async function filterStockEvents(ctx: Context, next: () => Promise<void>) {
+  if (!ctx.body.HasStockKeepingUnitModified) {
+    return
+  }
+  
+  await next()
+}

--- a/node/middlewares/stockFilter.ts
+++ b/node/middlewares/stockFilter.ts
@@ -1,0 +1,8 @@
+export async function stockFilterEvents(ctx: Context, next: () => Promise<void>) {
+  // Temporary if, in the near future broadcaster will only notify us modifications in SKUs or product.
+  if (!ctx.body.HasStockKeepingUnitModified) {
+    return
+  }
+  
+  await next()
+}

--- a/node/middlewares/stockFilter.ts
+++ b/node/middlewares/stockFilter.ts
@@ -1,8 +1,0 @@
-export async function stockFilterEvents(ctx: Context, next: () => Promise<void>) {
-  // Temporary if, in the near future broadcaster will only notify us modifications in SKUs or product.
-  if (!ctx.body.HasStockKeepingUnitModified) {
-    return
-  }
-  
-  await next()
-}

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -1874,7 +1874,7 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
-"stats-lite@github:vtex/node-stats-lite#dist":
+stats-lite@vtex/node-stats-lite#dist:
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:


### PR DESCRIPTION
### Purpose
This PR adds a filter of `HasStockKeepingUnitModified` property to maintain the same behavior, which is being removed from the Broadcaster app (PR https://github.com/vtex-apps/broadcaster/pull/57).

workspace: storecomponents/brasileiro